### PR TITLE
fix: limit the number of segments a JWT can be exploded into.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -107,7 +107,7 @@ class JWT
         if (empty($keyOrKeyArray)) {
             throw new InvalidArgumentException('Key may not be empty');
         }
-        $tks = \explode('.', $jwt);
+        $tks = \explode('.', $jwt, 4);
         if (\count($tks) !== 3) {
             throw new UnexpectedValueException('Wrong number of segments');
         }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -323,6 +323,21 @@ class JWTTest extends TestCase
         JWT::decode($encoded, $decodeKey);
     }
 
+    public function testInvalidTokenSegments()
+    {
+        $dummyToken = 'dGhlIHZhbHVlIGRvZXNuJ3QgbWF0dGVy.T25seSB0aGUgbnVtYmVyIG9mIHNlZ21lbnRz.VGhpcyBzaG91bGQgYmUgYSBzaWduYXR1cmU.YnV0IHRoZXJlIGlzIG1vcmU';
+        $this->expectException(UnexpectedValueException::class);
+        JWT::decode($dummyToken, $this->hmacKey);
+    }
+
+    public function testInvalidTokenManySegments()
+    {
+        $dummyToken = 'dGhlIHZhbHVlIGRvZXNuJ3QgbWF0dGVy.T25seSB0aGUgbnVtYmVyIG9mIHNlZ21lbnRz.VGhpcyBzaG91bGQgYmUgYSBzaWduYXR1cmU';
+        $dummyToken .= str_repeat('.KzE', 999999);
+        $this->expectException(UnexpectedValueException::class);
+        JWT::decode($dummyToken, $this->hmacKey);
+    }
+
     public function testNullKeyFails()
     {
         $payload = [


### PR DESCRIPTION
I was looking at CVE's for some go library that I use and came across [CVE-2025-30204](https://nvd.nist.gov/vuln/detail/CVE-2025-30204).

After looking at it I saw that this JWT library also has this issue so I decide to fix it.

When splitting the JWT into segments it now limits it to 4 segments max. Because after the 3rd segment the token is already invalid, so there is no need to split the token further. This avoids unneeded creation of memory for tokens that are invalid preventing a possible DOS.

I also added tests to verify these types of invalid tokens.